### PR TITLE
Remove harmful dependency to es6

### DIFF
--- a/community-server/build.gradle
+++ b/community-server/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     implementation "com.netflix.conductor:conductor-core:${revConductor}"
     implementation "com.netflix.conductor:conductor-redis-persistence:${revConductor}"
     implementation "com.netflix.conductor:conductor-cassandra-persistence:${revConductor}"
-    implementation "com.netflix.conductor:conductor-es6-persistence:${revConductor}"
     implementation "com.netflix.conductor:conductor-grpc-server:${revConductor}"
     implementation "com.netflix.conductor:conductor-redis-lock:${revConductor}"
     implementation "com.netflix.conductor:conductor-redis-concurrency-limit:${revConductor}"


### PR DESCRIPTION
By keeping this option the resources posted to es conflict with each other causing failures at index creation.

Pull Request type
----

- [X ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

Remove harmful dependency to es6
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
